### PR TITLE
feat: Get raylib via FetchContent if not found on the system

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "thirdparty/raylib"]
-	path = thirdparty/raylib
-	url = https://github.com/raysan5/raylib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11) # FetchContent requires CMake 3.11+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 # Set default build type to release
@@ -10,7 +10,24 @@ endif()
 project(GBPPlanner)
 add_compile_definitions(EIGEN_DONT_PARALLELIZE)
 find_package(OpenMP REQUIRED)
-add_subdirectory(thirdparty/raylib)
+
+# Get raylib based on the official raylib CMake project example
+# https://github.com/raysan5/raylib/blob/master/projects/CMake/CMakeLists.txt
+set(RAYLIB_VERSION 5.5)
+find_package(raylib ${RAYLIB_VERSION} QUIET) # QUIET or REQUIRED
+if (NOT raylib_FOUND) # If there's none, fetch and build raylib
+  include(FetchContent)
+  FetchContent_Declare(
+    raylib
+    DOWNLOAD_EXTRACT_TIMESTAMP OFF
+    URL https://github.com/raysan5/raylib/archive/refs/tags/${RAYLIB_VERSION}.tar.gz
+  )
+  FetchContent_GetProperties(raylib)
+  if (NOT raylib_POPULATED) # Have we downloaded raylib yet?
+    set(FETCHCONTENT_QUIET NO)
+    FetchContent_MakeAvailable(raylib)
+  endif()
+endif()
 
 #################################################################
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ Project page: https://aalpatya.github.io/gbpplanner
 **Watch the Code tutorial: https://www.youtube.com/watch?v=jvoPJ8GLiHk**
 
 ## Initial Setup
-Install Raylib dependencies as mentioned in https://github.com/raysan5/raylib#build-and-installation
-This will be platform dependent
+Install Raylib dependencies as mentioned in https://github.com/raysan5/raylib#build-and-installation.
+This will be platform dependent. For raylib itself, the CMakeLists.txt file should automatically find the library if it is already installed on your system, else, it will try and fetch it using FetchContent.
 
 Usually included with Linux (but you may need to install on other platforms)
 - [OpenMP](https://www.openmp.org/)
-- cmake (>=3.10)
+- cmake (>=3.11)
 - make
 
 Clone the repository *with the submodule dependencies:*
 ```shell
-git clone https://github.com/aalpatya/gbpplanner.git --recurse-submodules
+git clone https://github.com/aalpatya/gbpplanner.git
 cd gbpplanner
 ```
 Use CMAKE to set up the build environment and then run 'make':

--- a/src/gbp/Variable.cpp
+++ b/src/gbp/Variable.cpp
@@ -106,7 +106,7 @@ void Variable::delete_factor(Key fac_key){
 /***********************************************************************************************************/
 void Variable::draw(bool filled){
     if (draw_fn_!=NULL){
-        draw_fn_;
+        std::ignore = draw_fn_;
     } else {
         // Default variable draw function.
         if (!valid_) return;


### PR DESCRIPTION
This PR makes following simplifications:
1. Simplifies the way to get raylib if not installed on the system using FetchContent (inspired from the official raylib CMake example: https://github.com/raysan5/raylib/blob/master/projects/CMake/CMakeLists.txt)
1. Removes dependency on the submodule
1. Does not break anything if raylib is already present on the system
1. Generalizes the build process even more across the platforms

The above simplification made it very easy to build and experiment with this amazing work on macos targets. 😄 

Tested configuration:
- MacOS Sequoia 15.4.1 arm64
- cmake 4.0.2
- Apple clang version 17.0.0 (clang-1700.0.13.3)

<img width="1112" alt="Screenshot 2025-05-09 at 12 58 08 PM" src="https://github.com/user-attachments/assets/9d87d92d-a9ca-4ced-8618-be0ff4024cba" />

